### PR TITLE
feat: expose existing entries in admin editor

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,1700 @@
+const state = {
+    courses: [
+        {
+            id: 'firma',
+            title: 'Firma',
+            description: 'Şirket kültürünü ve temel süreçleri anlatan giriş eğitimi.',
+            modules: [
+                {
+                    id: 'history',
+                    title: 'Tarihimiz',
+                    duration: '08:30',
+                    type: 'video',
+                    source: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+                    summary: 'Şirketimizin kuruluş hikâyesi, dönüm noktaları ve büyüme yolculuğu.'
+                },
+                {
+                    id: 'vision',
+                    title: 'Vizyon & Değerler',
+                    duration: '06:10',
+                    type: 'video',
+                    source: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+                    summary: 'Kurumsal vizyonumuz, çalışan davranış ilkelerimiz ve liderlik yaklaşımımız.'
+                },
+                {
+                    id: 'production',
+                    title: 'Üretim & Depolar',
+                    duration: '12:00',
+                    type: 'youtube',
+                    youtubeId: 'Sagg08DrO5U',
+                    summary: 'Tüm üretim tesislerimizin turları, depo düzeni ve güvenlik kuralları.'
+                }
+            ],
+            quiz: {
+                title: '1. Bölüm - Firma',
+                questions: [
+                    {
+                        text: 'Şirketimizin kuruluş yılı aşağıdakilerden hangisidir?',
+                        options: ['1998', '2005', '2012'],
+                        answer: 0
+                    },
+                    {
+                        text: 'Kurumsal değerlerimizden biri değildir?',
+                        options: ['Müşteri odaklılık', 'Şeffaflık', 'Kısa vadeli düşünme'],
+                        answer: 2
+                    },
+                    {
+                        text: 'Depolarda güvenli giriş için ilk yapılması gereken?',
+                        options: ['Koruyucu ekipman takmak', 'Yemekhane alanını kontrol etmek', 'Ziyaretçi kartı almak'],
+                        answer: 0
+                    }
+                ]
+            }
+        },
+        {
+            id: 'urun',
+            title: 'Ürün Grupları',
+            description: 'Ürün portföyümüz ve teknik detaylarını öğrenin.',
+            modules: [
+                {
+                    id: 'pvc',
+                    title: 'PVC Boru ve Ek Parçalar',
+                    duration: '09:12',
+                    type: 'video',
+                    source: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+                    summary: 'PVC ürün ailesinin çeşitleri ve kullanım alanları.'
+                },
+                {
+                    id: 'pprc',
+                    title: 'PPRC Sistemleri',
+                    duration: '07:48',
+                    type: 'video',
+                    source: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+                    summary: 'PPRC ürün gamı ve montaj ipuçları.'
+                },
+                {
+                    id: 'silent',
+                    title: 'Sessiz Boru Sistemleri',
+                    duration: '10:05',
+                    type: 'youtube',
+                    youtubeId: '9No-FiEInLA',
+                    summary: 'Sessiz boru sistemlerinin avantajları ve referans projeler.'
+                }
+            ],
+            quiz: {
+                title: '2. Bölüm - Ürünler',
+                questions: [
+                    {
+                        text: 'PVC boruların en güçlü kullanım alanı nedir?',
+                        options: ['Elektrik tesisatı', 'Temiz su ve atık su hatları', 'Isıtma ve soğutma hatları'],
+                        answer: 1
+                    },
+                    {
+                        text: 'PPRC kaynak işleminde dikkat edilmesi gereken süre neyi etkiler?',
+                        options: ['Bağlantı dayanıklılığını', 'Ürünün rengini', 'Depo stok seviyesini'],
+                        answer: 0
+                    },
+                    {
+                        text: 'Sessiz boru sistemlerinin temel faydası nedir?',
+                        options: ['Maliyetin düşmesi', 'Akustik konfor sağlaması', 'Bakım gerektirmemesi'],
+                        answer: 1
+                    }
+                ]
+            }
+        },
+        {
+            id: 'isg',
+            title: 'İş Sağlığı ve Güvenliği',
+            description: 'Tüm çalışanlar için zorunlu İSG eğitimleri.',
+            modules: [
+                {
+                    id: 'fire',
+                    title: 'Acil Durum Prosedürleri',
+                    duration: '08:55',
+                    type: 'video',
+                    source: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+                    summary: 'Yangın, deprem ve tahliye süreçleri adım adım anlatılır.'
+                },
+                {
+                    id: 'ppe',
+                    title: 'Kişisel Koruyucu Ekipmanlar',
+                    duration: '06:22',
+                    type: 'video',
+                    source: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4',
+                    summary: 'Doğru ekipman seçimi ve kullanım örnekleri.'
+                },
+                {
+                    id: 'risk',
+                    title: 'Risk Bildirim Süreçleri',
+                    duration: '09:40',
+                    type: 'youtube',
+                    youtubeId: '2g811Eo7K8U',
+                    summary: 'Tehlike bildirim prosedürleri ve dijital platform kullanımı.'
+                }
+            ],
+            quiz: {
+                title: '3. Bölüm - İSG',
+                questions: [
+                    {
+                        text: 'Acil durum alarmı duyulduğunda ilk adım nedir?',
+                        options: ['İşe devam etmek', 'Çıkış planını uygulamak', 'Tüm pencereleri kapatmak'],
+                        answer: 1
+                    },
+                    {
+                        text: 'Koruyucu gözlük hangi durumlarda kullanılmalıdır?',
+                        options: ['Sadece dışarıda', 'Sadece bakımda', 'Kimyasal ve mekanik risk içeren tüm işlemlerde'],
+                        answer: 2
+                    },
+                    {
+                        text: 'Risk bildirim platformu ne zaman kullanılmalıdır?',
+                        options: ['Sadece kaza sonrası', 'Tehlike fark edildiği anda', 'Yılda bir'],
+                        answer: 1
+                    }
+                ]
+            }
+        }
+    ],
+    personalDevelopment: [
+        {
+            id: 'time',
+            title: 'Zaman Yönetimi Nasıl Geliştirilir?',
+            icon: '🕒',
+            body: 'Zaman yönetimi için önceliklendirme, hedef belirleme ve blok çalışma tekniklerini kullanın. Günün ilk saatlerinde en zor görevlere odaklanmak verimliliği artırır.'
+        },
+        {
+            id: 'customer',
+            title: 'Müşteri Nasıl İkna Edilir?',
+            icon: '🤝',
+            body: 'Empati kurun, müşterinin ihtiyacını doğru dinleyin ve çözümünüzün değerini net anlatın. Güven yaratmak için referans ve başarı hikâyelerinden yararlanın.'
+        },
+        {
+            id: 'leadership',
+            title: 'Liderlik ve Takım Yönetimi',
+            icon: '🧭',
+            body: 'Liderlik; vizyonu paylaşmak, ekip üyelerinin güçlü yönlerini ortaya çıkarmak ve düzenli geri bildirim vermekle başlar. Yetki devri motivasyonu yükseltir.'
+        },
+        {
+            id: 'decision',
+            title: 'Doğru Stratejik Karar Alma',
+            icon: '🎯',
+            body: 'Veriye dayalı karar süreçlerinde risk senaryolarını belirleyin. Kararlarınızı kurumsal hedeflerle hizalayın ve etkilenen paydaşlarla iletişim kurun.'
+        },
+        {
+            id: 'problem',
+            title: 'Problem Çözme Yeteneği',
+            icon: '🧩',
+            body: 'Kök neden analizi, beyin fırtınası ve hızlı prototip yöntemleri ile problemleri sistematik çözüme kavuşturabilirsiniz.'
+        },
+        {
+            id: 'cyber',
+            title: 'Siber Güvenlik Bilinci',
+            icon: '🔐',
+            body: 'Güçlü şifreler oluşturun, iki faktörlü doğrulamayı aktif edin ve phishing e-postalarına karşı dikkatli olun. Bilinmeyen bağlantılara tıklamayın.'
+        }
+    ],
+    faq: [
+        {
+            question: 'Yıllık izin hakkı nasıl hesaplanır?',
+            answer: 'Çalışma sürenize göre yıllık izin gün sayısı İnsan Kaynakları yönetmeliğinde belirtilmiştir. Portal üzerinden talepte bulunabilirsiniz.'
+        },
+        {
+            question: 'E-öğrenme modüllerine nereden ulaşırım?',
+            answer: 'Sol menüdeki Online Eğitimler sekmesinden kayıtlı olduğunuz tüm modüllere erişebilirsiniz.'
+        },
+        {
+            question: 'Sertifikamı nasıl indirebilirim?',
+            answer: 'Tüm zorunlu quizleri başarıyla tamamladıktan sonra Sertifika bölümündeki “Sertifikamı Al” butonu aktif hale gelir.'
+        }
+    ],
+    announcements: [
+        {
+            title: 'Şirket İçi İletişim Atölyesi',
+            body: '24.02.2025 tarihinde hibrit olarak gerçekleşecek atölyemize katılarak etkili iletişim tekniklerini öğrenebilirsiniz.',
+            icon: '📣'
+        },
+        {
+            title: 'Kurban Bayramı Tatil Takvimi',
+            body: 'Tatil döneminde üretim planlarımızı gözden geçirmek için vardiya yöneticilerinizle iletişime geçmeyi unutmayın.',
+            icon: '🗓️'
+        }
+    ],
+    quizResults: {},
+    moduleProgress: {},
+    activeCourseId: null,
+    activeModuleId: null,
+    isAdmin: false,
+    adminLoginError: '',
+    adminSelections: {
+        courseEdit: '',
+        moduleCourse: '',
+        moduleEdit: '',
+        quizCourse: '',
+        quizQuestion: '',
+        personal: '',
+        announcement: '',
+        faq: ''
+    },
+    youtubePlayer: null,
+    youtubeTracker: null,
+    youtubeAPIReady: typeof YT !== 'undefined' && !!YT.Player
+};
+
+const navButtons = document.querySelectorAll('.nav-item');
+const views = document.querySelectorAll('.view');
+const toastContainer = document.querySelector('.toast-container');
+const quizModal = document.getElementById('quizModal');
+const quizModalContent = document.getElementById('quizModalContent');
+const closeQuizModalButton = document.getElementById('closeQuizModal');
+
+const courseView = document.getElementById('online-trainings');
+const quizView = document.getElementById('quizzes');
+const personalView = document.getElementById('personal-growth');
+const faqView = document.getElementById('faq');
+const announcementView = document.getElementById('announcements');
+const adminView = document.getElementById('admin');
+
+function initProgress() {
+    state.courses.forEach(course => {
+        state.moduleProgress[course.id] = {};
+        course.modules.forEach(module => {
+            state.moduleProgress[course.id][module.id] = {
+                percent: 0,
+                completed: false
+            };
+        });
+    });
+}
+
+function showToast(message, type = 'info') {
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.textContent = message;
+    toastContainer.appendChild(toast);
+    setTimeout(() => {
+        toast.style.opacity = '0';
+        toast.style.transform = 'translateY(10px)';
+        setTimeout(() => toast.remove(), 350);
+    }, type === 'error' ? 4000 : 2500);
+}
+
+function setActiveView(targetId) {
+    views.forEach(view => view.classList.remove('active-view'));
+    const target = document.getElementById(targetId);
+    if (target) {
+        target.classList.add('active-view');
+    }
+    navButtons.forEach(button => {
+        button.classList.toggle('active', button.dataset.target === targetId);
+    });
+}
+
+navButtons.forEach(button => {
+    button.addEventListener('click', () => {
+        if (button.classList.contains('locked')) {
+            showToast('Bu bölüme erişebilmek için önceki gereksinimleri tamamlayın.', 'error');
+            return;
+        }
+        setActiveView(button.dataset.target);
+        renderView(button.dataset.target);
+    });
+});
+
+closeQuizModalButton.addEventListener('click', closeQuizModal);
+quizModal.addEventListener('click', event => {
+    if (event.target === quizModal) {
+        closeQuizModal();
+    }
+});
+
+function closeQuizModal() {
+    quizModal.setAttribute('aria-hidden', 'true');
+    quizModal.classList.remove('show');
+    quizModalContent.innerHTML = '';
+}
+
+function renderView(viewId) {
+    switch (viewId) {
+        case 'online-trainings':
+            renderOnlineTrainings();
+            break;
+        case 'quizzes':
+            renderQuizzes();
+            break;
+        case 'personal-growth':
+            renderPersonalGrowth();
+            break;
+        case 'faq':
+            renderFaq();
+            break;
+        case 'announcements':
+            renderAnnouncements();
+            break;
+        case 'admin':
+            renderAdminPanel();
+            break;
+    }
+}
+
+function getUnlockedCourseIndex() {
+    return state.courses.findIndex(course => !isCourseCompleted(course));
+}
+
+function isCourseCompleted(course) {
+    const allModulesDone = course.modules.every(module => state.moduleProgress[course.id][module.id].completed);
+    const quizResult = state.quizResults[course.id];
+    return allModulesDone && quizResult && quizResult.passed;
+}
+
+function calculateCourseProgress(course) {
+    if (!course.modules.length) return 0;
+    const moduleStates = state.moduleProgress[course.id];
+    const totalPercent = Object.values(moduleStates).reduce((acc, value) => acc + value.percent, 0);
+    return Math.floor(totalPercent / course.modules.length);
+}
+
+function renderOnlineTrainings() {
+    courseView.innerHTML = '';
+
+    const header = document.createElement('div');
+    header.className = 'section-header';
+    header.innerHTML = `
+        <div>
+            <h2>Online Eğitimler</h2>
+            <p class="section-description">Modülleri sırasıyla tamamlayın, ardından quizlere katılarak sertifikanızı kazanın.</p>
+        </div>
+        <div class="badge-chip">🎯 Sıralı İlerleme Aktif</div>
+    `;
+
+    courseView.appendChild(header);
+
+    const grid = document.createElement('div');
+    grid.className = 'course-grid';
+    courseView.appendChild(grid);
+
+    const unlockedIndex = getUnlockedCourseIndex();
+    const lockIndex = unlockedIndex === -1 ? state.courses.length : unlockedIndex;
+
+    state.courses.forEach((course, index) => {
+        const courseCard = document.createElement('article');
+        courseCard.className = 'course-card';
+        courseCard.dataset.courseId = course.id;
+        if (index > lockIndex) {
+            courseCard.classList.add('locked');
+        }
+
+        const progress = calculateCourseProgress(course);
+        const modulesCompleted = course.modules.filter(module => state.moduleProgress[course.id][module.id].completed).length;
+
+        courseCard.innerHTML = `
+            <div>
+                <h3>${course.title}</h3>
+                <p class="section-description">${course.description}</p>
+            </div>
+            <div class="training-progress-summary" data-course-summary="${course.id}">
+                <span>Modül Tamamlanma: ${modulesCompleted}/${course.modules.length}</span>
+                <span class="percentage">%${progress}</span>
+            </div>
+        `;
+
+        const moduleList = document.createElement('div');
+        moduleList.className = 'module-list';
+
+        course.modules.forEach((module, moduleIndex) => {
+            const moduleItem = document.createElement('button');
+            moduleItem.type = 'button';
+            moduleItem.className = 'module-item';
+            moduleItem.dataset.courseId = course.id;
+            moduleItem.dataset.moduleId = module.id;
+            moduleItem.dataset.moduleIndex = moduleIndex;
+
+            const moduleState = state.moduleProgress[course.id][module.id];
+            const locked = index > lockIndex || (moduleIndex > 0 && !state.moduleProgress[course.id][course.modules[moduleIndex - 1].id].completed);
+
+            if (locked) {
+                moduleItem.classList.add('locked');
+            }
+
+            moduleItem.innerHTML = `
+                <div class="module-meta">
+                    <strong>${moduleIndex + 1}. Modül - ${module.title}</strong>
+                    <span>${module.duration}</span>
+                </div>
+                <p class="section-description">${module.summary}</p>
+                <div class="progress-bar"><span data-progress-key="${course.id}::${module.id}" style="width:${moduleState.percent}%"></span></div>
+                <small class="module-status" data-status-key="${course.id}::${module.id}">${moduleState.completed ? 'Tamamlandı ✅' : `İzlenme Oranı: %${moduleState.percent}`}</small>
+            `;
+
+            moduleItem.addEventListener('click', () => {
+                if (moduleItem.classList.contains('locked')) {
+                    showToast('Bu modüle geçmeden önce önceki modülü tamamlayın.', 'error');
+                    return;
+                }
+                state.activeCourseId = course.id;
+                state.activeModuleId = module.id;
+                openModule(course, module);
+            });
+
+            moduleList.appendChild(moduleItem);
+        });
+
+        if (!course.modules.length) {
+            const empty = document.createElement('div');
+            empty.className = 'empty-state';
+            empty.style.padding = '20px';
+            empty.textContent = 'Henüz modül eklenmemiş. Yönetim panelinden içerik oluşturun.';
+            moduleList.appendChild(empty);
+        }
+
+        courseCard.appendChild(moduleList);
+        grid.appendChild(courseCard);
+    });
+
+    const playerPanel = document.createElement('section');
+    playerPanel.className = 'player-panel';
+    playerPanel.innerHTML = `
+        <h3>Modül İçeriği</h3>
+        <div id="videoContainer">
+            <div class="empty-state">
+                <p>Bir modül seçtiğinizde video burada açılacaktır.</p>
+            </div>
+        </div>
+        <div class="module-info"></div>
+    `;
+    courseView.appendChild(playerPanel);
+
+    refreshCourseAccess();
+    state.courses.forEach(course => refreshModuleLocks(course.id));
+
+    if (state.activeCourseId && state.activeModuleId) {
+        const course = state.courses.find(item => item.id === state.activeCourseId);
+        const module = course?.modules.find(item => item.id === state.activeModuleId);
+        if (course && module) {
+            openModule(course, module);
+        }
+    }
+}
+
+function openModule(course, module) {
+    const playerPanel = document.querySelector('.player-panel');
+    const videoContainer = playerPanel.querySelector('#videoContainer');
+    const moduleInfo = playerPanel.querySelector('.module-info');
+
+    moduleInfo.innerHTML = `
+        <h4>${course.title} · ${module.title}</h4>
+        <p>${module.summary}</p>
+    `;
+
+    if (state.youtubePlayer) {
+        state.youtubePlayer.stopVideo?.();
+        state.youtubePlayer.destroy?.();
+        state.youtubePlayer = null;
+    }
+    if (state.youtubeTracker) {
+        clearInterval(state.youtubeTracker);
+        state.youtubeTracker = null;
+    }
+
+    if (module.type === 'video') {
+        const video = document.createElement('video');
+        video.src = module.source;
+        video.controls = true;
+        video.setAttribute('playsinline', 'true');
+        videoContainer.innerHTML = '';
+        videoContainer.appendChild(video);
+
+        video.addEventListener('timeupdate', () => {
+            if (!video.duration) return;
+            const percent = Math.min(100, Math.floor((video.currentTime / video.duration) * 100));
+            updateModuleProgress(course.id, module.id, percent);
+        });
+
+        video.addEventListener('ended', () => {
+            updateModuleProgress(course.id, module.id, 100, true);
+        });
+    } else if (module.type === 'youtube') {
+        const iframeContainer = document.createElement('div');
+        iframeContainer.id = 'youtubePlayer';
+        videoContainer.innerHTML = '';
+        videoContainer.appendChild(iframeContainer);
+
+        if (state.youtubeAPIReady) {
+            createYouTubePlayer(course, module);
+        } else {
+            state.pendingYouTubeModule = { course, module };
+        }
+    }
+}
+
+window.onYouTubeIframeAPIReady = () => {
+    state.youtubeAPIReady = true;
+    if (state.pendingYouTubeModule) {
+        const { course, module } = state.pendingYouTubeModule;
+        createYouTubePlayer(course, module);
+        state.pendingYouTubeModule = null;
+    }
+};
+
+function createYouTubePlayer(course, module) {
+    state.youtubePlayer = new YT.Player('youtubePlayer', {
+        videoId: module.youtubeId,
+        playerVars: {
+            controls: 1,
+            rel: 0,
+            modestbranding: 1
+        },
+        events: {
+            onReady: event => {
+                state.youtubeTracker = setInterval(() => {
+                    const duration = event.target.getDuration();
+                    if (duration > 0) {
+                        const percent = Math.min(100, Math.floor((event.target.getCurrentTime() / duration) * 100));
+                        updateModuleProgress(course.id, module.id, percent);
+                    }
+                }, 1000);
+            },
+            onStateChange: event => {
+                if (event.data === YT.PlayerState.ENDED) {
+                    updateModuleProgress(course.id, module.id, 100, true);
+                }
+            }
+        }
+    });
+}
+
+function updateModuleProgress(courseId, moduleId, percent, forceComplete = false) {
+    const moduleState = state.moduleProgress[courseId][moduleId];
+    const nextPercent = forceComplete ? 100 : Math.max(moduleState.percent, percent);
+    const completed = forceComplete || nextPercent >= 95;
+    const hasChanged = nextPercent !== moduleState.percent || completed !== moduleState.completed;
+
+    if (!hasChanged) return;
+
+    state.moduleProgress[courseId][moduleId] = {
+        percent: nextPercent,
+        completed
+    };
+    refreshModuleUI(courseId, moduleId);
+    refreshCourseSummary(courseId);
+    refreshCourseAccess();
+
+    if (completed && !moduleState.completed) {
+        showToast('Tebrikler! Bu modülü tamamladınız.');
+        const course = state.courses.find(item => item.id === courseId);
+        const allModulesDone = course?.modules.every(module => state.moduleProgress[courseId][module.id].completed);
+        if (allModulesDone) {
+            renderQuizzes();
+            if (!isCourseCompleted(course)) {
+                showToast('Tüm modülleri tamamladınız. Quiz çözerek eğitimi bitirebilirsiniz.');
+            }
+        }
+        if (isCourseCompleted(course)) {
+            showToast('Eğitimi tamamladınız. Quiz bölümüne geçebilirsiniz.');
+        }
+    }
+}
+
+function refreshModuleUI(courseId, moduleId) {
+    const key = `${courseId}::${moduleId}`;
+    const moduleState = state.moduleProgress[courseId][moduleId];
+    const progressEl = document.querySelector(`.progress-bar span[data-progress-key="${key}"]`);
+    const statusEl = document.querySelector(`.module-status[data-status-key="${key}"]`);
+    if (progressEl) {
+        progressEl.style.width = `${moduleState.percent}%`;
+    }
+    if (statusEl) {
+        statusEl.textContent = moduleState.completed ? 'Tamamlandı ✅' : `İzlenme Oranı: %${moduleState.percent}`;
+    }
+}
+
+function refreshCourseSummary(courseId) {
+    const course = state.courses.find(item => item.id === courseId);
+    if (!course) return;
+    const summary = document.querySelector(`.training-progress-summary[data-course-summary="${courseId}"]`);
+    if (!summary) return;
+    const modulesCompleted = course.modules.filter(module => state.moduleProgress[course.id][module.id].completed).length;
+    const progressPercent = calculateCourseProgress(course);
+    const [countEl, percentEl] = summary.querySelectorAll('span');
+    if (countEl) countEl.textContent = `Modül Tamamlanma: ${modulesCompleted}/${course.modules.length}`;
+    if (percentEl) percentEl.textContent = `%${progressPercent}`;
+}
+
+function refreshModuleLocks(courseId, courseLockedOverride = null) {
+    const course = state.courses.find(item => item.id === courseId);
+    if (!course) return;
+    const unlockedIndex = getUnlockedCourseIndex();
+    const lockIndex = unlockedIndex === -1 ? state.courses.length : unlockedIndex;
+    const courseIndex = state.courses.findIndex(item => item.id === courseId);
+    const courseLocked = courseLockedOverride !== null ? courseLockedOverride : courseIndex > lockIndex;
+
+    course.modules.forEach((module, index) => {
+        const button = document.querySelector(`.module-item[data-course-id="${courseId}"][data-module-id="${module.id}"]`);
+        if (!button) return;
+        const prevCompleted = index === 0 || state.moduleProgress[courseId][course.modules[index - 1].id].completed;
+        if (courseLocked || !prevCompleted) {
+            button.classList.add('locked');
+        } else {
+            button.classList.remove('locked');
+        }
+    });
+}
+
+function refreshCourseAccess() {
+    const unlockedIndex = getUnlockedCourseIndex();
+    const lockIndex = unlockedIndex === -1 ? state.courses.length : unlockedIndex;
+    state.courses.forEach((course, index) => {
+        const card = document.querySelector(`.course-card[data-course-id="${course.id}"]`);
+        if (!card) return;
+        if (index > lockIndex) {
+            card.classList.add('locked');
+        } else {
+            card.classList.remove('locked');
+        }
+        refreshModuleLocks(course.id, index > lockIndex);
+    });
+}
+
+function renderQuizzes() {
+    quizView.innerHTML = '';
+
+    const header = document.createElement('div');
+    header.className = 'section-header';
+    header.innerHTML = `
+        <div>
+            <h2>Quizler ve Sertifikalar</h2>
+            <p class="section-description">Her kursu tamamladıktan sonra quizini çözerek ilerleyin. %50 üzeri başarı ile geçer not alırsınız.</p>
+        </div>
+    `;
+    quizView.appendChild(header);
+
+    const grid = document.createElement('div');
+    grid.className = 'quiz-grid';
+    quizView.appendChild(grid);
+
+    state.courses.forEach((course, index) => {
+        const quizCard = document.createElement('article');
+        quizCard.className = 'quiz-card';
+
+        const quizResult = state.quizResults[course.id];
+        const modulesCompleted = course.modules.every(module => state.moduleProgress[course.id][module.id].completed);
+        const totalQuestions = course.quiz.questions.length;
+        const disabled = !modulesCompleted || (index > 0 && !isCourseCompleted(state.courses[index - 1])) || totalQuestions === 0;
+
+        let statusText = 'Hazır';
+        if (totalQuestions === 0) {
+            statusText = 'Hazırlanıyor';
+        } else if (quizResult) {
+            statusText = quizResult.passed ? 'BAŞARILI' : 'BAŞARISIZ';
+        }
+        const badgeClass = quizResult ? (quizResult.passed ? 'badge-pass' : 'badge-fail') : '';
+
+        quizCard.innerHTML = `
+            <div>
+                <h3>${course.quiz.title}</h3>
+                <p class="section-description">${course.title} eğitimini pekiştirmek için ${totalQuestions} soruluk quiz.</p>
+            </div>
+            <div class="quiz-result">
+                <span>✅ Doğru: ${quizResult ? quizResult.correct : 0}</span>
+                <span>❌ Yanlış: ${quizResult ? quizResult.wrong : 0}</span>
+            </div>
+            <div class="quiz-actions">
+                <span class="${badgeClass}">${statusText}</span>
+                <button ${disabled ? 'disabled class="locked"' : ''}>Testi Başlat</button>
+            </div>
+        `;
+
+        const startButton = quizCard.querySelector('button');
+        startButton.addEventListener('click', () => {
+            if (disabled) {
+                if (totalQuestions === 0) {
+                    showToast('Bu quiz henüz hazırlanıyor. Yönetici tarafından sorular eklendiğinde aktif olacaktır.');
+                } else {
+                    showToast('Quiz açılmadan önce tüm modülleri tamamlayın.', 'error');
+                }
+                return;
+            }
+            openQuiz(course);
+        });
+
+        grid.appendChild(quizCard);
+    });
+
+    renderCertificateBanner();
+}
+
+function openQuiz(course) {
+    quizModalContent.innerHTML = '';
+    const title = document.createElement('h3');
+    title.id = 'quizModalTitle';
+    title.textContent = course.quiz.title;
+    quizModalContent.appendChild(title);
+
+    const form = document.createElement('form');
+    course.quiz.questions.forEach((question, qIndex) => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'quiz-question';
+        const questionTitle = document.createElement('h4');
+        questionTitle.textContent = `${qIndex + 1}. ${question.text}`;
+        wrapper.appendChild(questionTitle);
+
+        const optionsWrapper = document.createElement('div');
+        optionsWrapper.className = 'quiz-options';
+
+        question.options.forEach((option, optionIndex) => {
+            const optionId = `${course.id}-${qIndex}-${optionIndex}`;
+            const label = document.createElement('label');
+            const input = document.createElement('input');
+            input.type = 'radio';
+            input.name = `${course.id}-${qIndex}`;
+            input.value = optionIndex;
+            input.id = optionId;
+            label.htmlFor = optionId;
+            label.appendChild(input);
+            const span = document.createElement('span');
+            span.textContent = option;
+            label.appendChild(span);
+            optionsWrapper.appendChild(label);
+        });
+
+        wrapper.appendChild(optionsWrapper);
+        form.appendChild(wrapper);
+    });
+
+    const footer = document.createElement('div');
+    footer.className = 'quiz-footer';
+    const info = document.createElement('p');
+    info.className = 'section-description';
+    info.textContent = 'Geçmek için soruların yarısından fazlasını doğru yanıtlamalısınız.';
+    const submitButton = document.createElement('button');
+    submitButton.type = 'submit';
+    submitButton.className = 'primary';
+    submitButton.textContent = 'Quiz Sonuçlarını Hesapla';
+    footer.appendChild(info);
+    footer.appendChild(submitButton);
+    form.appendChild(footer);
+
+    form.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        let correct = 0;
+        course.quiz.questions.forEach((question, qIndex) => {
+            const answer = formData.get(`${course.id}-${qIndex}`);
+            if (answer !== null && Number(answer) === question.answer) {
+                correct += 1;
+            }
+        });
+        const total = course.quiz.questions.length;
+        const wrong = total - correct;
+        const passed = correct > total / 2;
+        const scorePercent = Math.round((correct / total) * 100);
+
+        state.quizResults[course.id] = {
+            correct,
+            wrong,
+            passed,
+            scorePercent
+        };
+
+        closeQuizModal();
+        showToast(`Quiz tamamlandı. Skorunuz: %${scorePercent}`);
+        renderQuizzes();
+    });
+
+    quizModalContent.appendChild(form);
+    quizModal.setAttribute('aria-hidden', 'false');
+    quizModal.classList.add('show');
+}
+
+function renderCertificateBanner() {
+    const existingBanner = quizView.querySelector('.certificate-banner');
+    if (existingBanner) existingBanner.remove();
+
+    const results = state.courses.map(course => state.quizResults[course.id]);
+    const allCompleted = results.every(result => result && result.passed);
+    const highScores = results.every(result => result && result.scorePercent >= 80);
+    const attempts = results.filter(Boolean).length;
+
+    const banner = document.createElement('div');
+    banner.className = 'certificate-banner';
+
+    if (results.length === attempts && allCompleted && highScores) {
+        banner.innerHTML = `
+            <strong>🎉 Sertifika Almaya Hak Kazandınız!</strong>
+            <p>Tüm quizlerde %80 ve üzeri başarı gösterdiniz. Sertifikanızı indirerek paylaşabilirsiniz.</p>
+            <button type="button" onclick="alert('Sertifikanız indiriliyor...')">Sertifikamı Al</button>
+        `;
+    } else {
+        const average = attempts ? Math.round(results.filter(Boolean).reduce((acc, val) => acc + val.scorePercent, 0) / attempts) : 0;
+        banner.innerHTML = `
+            <strong>🎯 Sertifika Hedefine Ulaşın</strong>
+            <p>Tüm kurs quizlerinden %80 ve üzeri puan alarak sertifikanızı kazanın. Güncel ortalama skorunuz: %${average}</p>
+            <span>Eksik quizleri tamamlayın ve tekrar deneyin.</span>
+        `;
+    }
+
+    quizView.appendChild(banner);
+}
+
+function renderPersonalGrowth() {
+    personalView.innerHTML = '';
+
+    const header = document.createElement('div');
+    header.className = 'section-header';
+    header.innerHTML = `
+        <div>
+            <h2>Kişisel Gelişim</h2>
+            <p class="section-description">Kartlara tıklayarak konuya özel okuma içeriklerini görüntüleyin.</p>
+        </div>
+    `;
+    personalView.appendChild(header);
+
+    const grid = document.createElement('div');
+    grid.className = 'personal-grid';
+    personalView.appendChild(grid);
+
+    state.personalDevelopment.forEach(article => {
+        const card = document.createElement('article');
+        card.className = 'personal-card';
+        card.innerHTML = `
+            <div class="personal-icon" style="font-size:40px;">${article.icon}</div>
+            <h3>${article.title}</h3>
+        `;
+        card.addEventListener('click', () => {
+            renderPersonalReader(article);
+        });
+        grid.appendChild(card);
+    });
+
+    const reader = document.createElement('div');
+    reader.className = 'personal-reader';
+    reader.innerHTML = `
+        <h3>Bir başlık seçin</h3>
+        <p class="section-description">Okuma paneli, seçtiğiniz konu başlığının detaylarını burada gösterecektir.</p>
+    `;
+    personalView.appendChild(reader);
+}
+
+function renderPersonalReader(article) {
+    const reader = personalView.querySelector('.personal-reader');
+    reader.innerHTML = `
+        <h3>${article.title}</h3>
+        <p>${article.body}</p>
+    `;
+}
+
+function renderFaq() {
+    faqView.innerHTML = '';
+    const header = document.createElement('div');
+    header.className = 'section-header';
+    header.innerHTML = `
+        <div>
+            <h2>Sıkça Sorulan Sorular</h2>
+            <p class="section-description">Portal ve İK süreçlerine dair merak edilenler.</p>
+        </div>
+    `;
+    faqView.appendChild(header);
+
+    const accordion = document.createElement('div');
+    accordion.className = 'accordion';
+
+    state.faq.forEach((item, index) => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'accordion-item';
+        const button = document.createElement('button');
+        button.className = 'accordion-button';
+        button.innerHTML = `<span>${index + 1}. ${item.question}</span><span>▼</span>`;
+        const content = document.createElement('div');
+        content.className = 'accordion-content';
+        content.style.display = 'none';
+        content.textContent = item.answer;
+
+        button.addEventListener('click', () => {
+            const isOpen = content.style.display === 'block';
+            content.style.display = isOpen ? 'none' : 'block';
+            button.querySelector('span:last-child').textContent = isOpen ? '▼' : '▲';
+        });
+
+        wrapper.appendChild(button);
+        wrapper.appendChild(content);
+        accordion.appendChild(wrapper);
+    });
+
+    faqView.appendChild(accordion);
+}
+
+function renderAnnouncements() {
+    announcementView.innerHTML = '';
+    const header = document.createElement('div');
+    header.className = 'section-header';
+    header.innerHTML = `
+        <div>
+            <h2>Duyurular ve Etkinlikler</h2>
+            <p class="section-description">Güncel etkinlik ve duyurularımız.</p>
+        </div>
+    `;
+    announcementView.appendChild(header);
+
+    if (!state.announcements.length) {
+        announcementView.insertAdjacentHTML('beforeend', '<div class="empty-state">Henüz bir duyuru bulunmuyor.</div>');
+        return;
+    }
+
+    const list = document.createElement('div');
+    list.className = 'announcement-list';
+
+    state.announcements.forEach(item => {
+        const card = document.createElement('article');
+        card.className = 'announcement-card';
+        card.innerHTML = `
+            <div class="announcement-icon">${item.icon}</div>
+            <div>
+                <h3>${item.title}</h3>
+                <p class="section-description">${item.body}</p>
+            </div>
+        `;
+        list.appendChild(card);
+    });
+
+    announcementView.appendChild(list);
+}
+
+function normalizeAdminSelections() {
+    const selections = state.adminSelections;
+    if (!selections) return;
+
+    const courses = state.courses;
+    const firstCourse = courses[0];
+    if (!courses.find(course => course.id === selections.courseEdit)) {
+        selections.courseEdit = firstCourse ? firstCourse.id : '';
+    }
+
+    const coursesWithModules = courses.filter(course => course.modules.length);
+    const moduleCourse = coursesWithModules.find(course => course.id === selections.moduleCourse) || coursesWithModules[0];
+    selections.moduleCourse = moduleCourse ? moduleCourse.id : '';
+    if (moduleCourse) {
+        const module = moduleCourse.modules.find(item => item.id === selections.moduleEdit) || moduleCourse.modules[0];
+        selections.moduleEdit = module ? module.id : '';
+    } else {
+        selections.moduleEdit = '';
+    }
+
+    const quizCourses = courses.filter(course => course.quiz && course.quiz.questions.length);
+    const quizCourse = quizCourses.find(course => course.id === selections.quizCourse) || quizCourses[0];
+    selections.quizCourse = quizCourse ? quizCourse.id : '';
+    if (quizCourse && quizCourse.quiz.questions.length) {
+        const questionIndex = Number(selections.quizQuestion);
+        selections.quizQuestion = Number.isInteger(questionIndex) && quizCourse.quiz.questions[questionIndex]
+            ? String(questionIndex)
+            : '0';
+    } else {
+        selections.quizQuestion = '';
+    }
+
+    if (!state.personalDevelopment.find(item => item.id === selections.personal)) {
+        selections.personal = state.personalDevelopment[0] ? state.personalDevelopment[0].id : '';
+    }
+
+    const announcementIndex = Number(selections.announcement);
+    if (!Number.isInteger(announcementIndex) || !state.announcements[announcementIndex]) {
+        selections.announcement = state.announcements.length ? '0' : '';
+    }
+
+    const faqIndex = Number(selections.faq);
+    if (!Number.isInteger(faqIndex) || !state.faq[faqIndex]) {
+        selections.faq = state.faq.length ? '0' : '';
+    }
+}
+
+function renderAdminPanel() {
+    adminView.innerHTML = '';
+
+    if (!state.isAdmin) {
+        const loginCard = document.createElement('div');
+        loginCard.className = 'admin-card';
+        loginCard.innerHTML = `
+            <h3>Yönetici Girişi</h3>
+            <p class="section-description">İçerik ekleme, silme ve düzenleme işlemleri yalnızca yönetici hesapları ile yapılabilir.</p>
+            <form id="adminLoginForm">
+                <input type="email" name="email" placeholder="E-posta" autocomplete="username" required>
+                <input type="password" name="password" placeholder="Şifre" autocomplete="current-password" required>
+                <button type="submit">Giriş Yap</button>
+                ${state.adminLoginError ? `<p class="section-description" style="color: var(--danger);">${state.adminLoginError}</p>` : ''}
+            </form>
+        `;
+
+        adminView.appendChild(loginCard);
+
+        const form = loginCard.querySelector('#adminLoginForm');
+        form.addEventListener('submit', event => {
+            event.preventDefault();
+            const formData = new FormData(form);
+            const email = (formData.get('email') || '').toString().trim().toLowerCase();
+            const password = (formData.get('password') || '').toString().trim();
+            if (email === 'mthnkrgl6@gmail.com' && password === '123456') {
+                state.isAdmin = true;
+                state.adminLoginError = '';
+                showToast('Yönetici girişi başarılı.');
+                renderAdminPanel();
+            } else {
+                state.adminLoginError = 'Bilgiler hatalı. Tekrar deneyin.';
+                renderAdminPanel();
+            }
+        });
+        return;
+    }
+
+    normalizeAdminSelections();
+
+    const adminPanel = document.createElement('div');
+    adminPanel.className = 'admin-panel';
+
+    adminPanel.appendChild(createCourseManager());
+    adminPanel.appendChild(createModuleManager());
+    adminPanel.appendChild(createQuizManager());
+    adminPanel.appendChild(createPersonalManager());
+    adminPanel.appendChild(createAnnouncementManager());
+    adminPanel.appendChild(createFaqManager());
+
+    adminView.appendChild(adminPanel);
+}
+
+function createCourseManager() {
+    const card = document.createElement('div');
+    card.className = 'admin-card';
+    const { courseEdit } = state.adminSelections;
+    card.innerHTML = `
+        <h3>Kurs Yönetimi</h3>
+        <form id="courseForm">
+            <input type="text" name="title" placeholder="Kurs Başlığı" required>
+            <textarea name="description" placeholder="Kurs açıklaması" required></textarea>
+            <button type="submit">Kurs Ekle</button>
+        </form>
+        <div class="inline-list">
+            ${state.courses.map(course => `<button data-course="${course.id}"><span>${course.title}</span> <i>Sil</i></button>`).join('')}
+        </div>
+        ${state.courses.length ? `
+            <div class="admin-divider"></div>
+            <h4>Kurs Düzenle</h4>
+            <form id="courseEditForm">
+                <select name="course" required>
+                    ${state.courses.map(course => `<option value="${course.id}" ${course.id === courseEdit ? 'selected' : ''}>${course.title}</option>`).join('')}
+                </select>
+                <input type="text" name="title" placeholder="Kurs Başlığı" required>
+                <textarea name="description" placeholder="Kurs açıklaması" required></textarea>
+                <button type="submit">Kursu Güncelle</button>
+            </form>
+        ` : ''}
+    `;
+
+    const form = card.querySelector('#courseForm');
+    form.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        const title = formData.get('title');
+        const description = formData.get('description');
+        const id = title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+        state.courses.push({
+            id,
+            title,
+            description,
+            modules: [],
+            quiz: { title: `${title} Quiz`, questions: [] }
+        });
+        state.moduleProgress[id] = {};
+        form.reset();
+        renderAdminPanel();
+        renderOnlineTrainings();
+        renderQuizzes();
+        showToast('Yeni kurs eklendi.');
+    });
+
+    card.querySelectorAll('.inline-list button').forEach(button => {
+        button.addEventListener('click', () => {
+            const courseId = button.dataset.course;
+            const index = state.courses.findIndex(course => course.id === courseId);
+            if (index > -1) {
+                state.courses.splice(index, 1);
+                delete state.moduleProgress[courseId];
+                delete state.quizResults[courseId];
+                renderAdminPanel();
+                renderOnlineTrainings();
+                renderQuizzes();
+                showToast('Kurs silindi.');
+            }
+        });
+    });
+
+    const editForm = card.querySelector('#courseEditForm');
+    if (editForm) {
+        const select = editForm.querySelector('select[name="course"]');
+        const titleInput = editForm.querySelector('input[name="title"]');
+        const descriptionInput = editForm.querySelector('textarea[name="description"]');
+        const selectedCourse = state.courses.find(course => course.id === select.value);
+        if (selectedCourse) {
+            titleInput.value = selectedCourse.title;
+            descriptionInput.value = selectedCourse.description;
+        }
+
+        select.addEventListener('change', () => {
+            state.adminSelections.courseEdit = select.value;
+            renderAdminPanel();
+        });
+
+        editForm.addEventListener('submit', event => {
+            event.preventDefault();
+            const targetCourse = state.courses.find(course => course.id === select.value);
+            if (!targetCourse) return;
+            targetCourse.title = titleInput.value;
+            targetCourse.description = descriptionInput.value;
+            if (targetCourse.quiz) {
+                targetCourse.quiz.title = `${titleInput.value} Quiz`;
+            }
+            renderAdminPanel();
+            renderOnlineTrainings();
+            renderQuizzes();
+            showToast('Kurs bilgileri güncellendi.');
+        });
+    }
+
+    return card;
+}
+
+function createModuleManager() {
+    const card = document.createElement('div');
+    card.className = 'admin-card';
+    const { moduleCourse, moduleEdit } = state.adminSelections;
+    const editableCourses = state.courses.filter(course => course.modules.length);
+    const selectedCourse = editableCourses.find(course => course.id === moduleCourse) || editableCourses[0] || null;
+    const moduleOptions = selectedCourse ? selectedCourse.modules : [];
+    const hasModules = editableCourses.length > 0;
+    card.innerHTML = `
+        <h3>Modül Yönetimi</h3>
+        <form id="moduleForm">
+            <select name="course" required>
+                <option value="">Kurs seçin</option>
+                ${state.courses.map(course => `<option value="${course.id}">${course.title}</option>`).join('')}
+            </select>
+            <input type="text" name="title" placeholder="Modül Başlığı" required>
+            <input type="text" name="duration" placeholder="Süre örn. 08:30" required>
+            <select name="type" required>
+                <option value="video">Video (MP4)</option>
+                <option value="youtube">YouTube</option>
+            </select>
+            <input type="url" name="source" placeholder="Video URL veya YouTube bağlantısı" required>
+            <textarea name="summary" placeholder="Modül özeti" required></textarea>
+            <button type="submit">Modül Ekle</button>
+        </form>
+        <div class="admin-divider"></div>
+        <h4>Modül Düzenle</h4>
+        ${hasModules ? `
+            <form id="moduleEditForm">
+                <select name="course" required>
+                    ${editableCourses.map(course => `<option value="${course.id}" ${selectedCourse && selectedCourse.id === course.id ? 'selected' : ''}>${course.title}</option>`).join('')}
+                </select>
+                <select name="module" required>
+                    ${moduleOptions.map(module => `<option value="${module.id}" ${module.id === moduleEdit ? 'selected' : ''}>${module.title}</option>`).join('')}
+                </select>
+                <input type="text" name="title" placeholder="Modül Başlığı" required>
+                <input type="text" name="duration" placeholder="Süre örn. 08:30" required>
+                <select name="type" required>
+                    <option value="video">Video (MP4)</option>
+                    <option value="youtube">YouTube</option>
+                </select>
+                <input type="url" name="source" placeholder="Video URL veya YouTube bağlantısı" required>
+                <textarea name="summary" placeholder="Modül özeti" required></textarea>
+                <button type="submit">Modülü Güncelle</button>
+            </form>
+        ` : '<p class="section-description">Düzenlenecek modül bulunmuyor.</p>'}
+    `;
+
+    const form = card.querySelector('#moduleForm');
+    form.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        const courseId = formData.get('course');
+        const course = state.courses.find(item => item.id === courseId);
+        if (!course) return;
+        const title = formData.get('title');
+        const duration = formData.get('duration');
+        const type = formData.get('type');
+        const source = formData.get('source');
+        const summary = formData.get('summary');
+        const moduleId = `${courseId}-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+
+        const newModule = {
+            id: moduleId,
+            title,
+            duration,
+            type,
+            summary
+        };
+
+        if (type === 'youtube') {
+            const match = source.match(/(?:v=|\.be\/|embed\/)([A-Za-z0-9_-]{11})/);
+            newModule.youtubeId = match ? match[1] : source.slice(-11);
+        } else {
+            newModule.source = source;
+        }
+
+        course.modules.push(newModule);
+        state.moduleProgress[courseId][moduleId] = { percent: 0, completed: false };
+        form.reset();
+        renderAdminPanel();
+        renderOnlineTrainings();
+        showToast('Modül eklendi.');
+    });
+
+    const editForm = card.querySelector('#moduleEditForm');
+    if (editForm) {
+        const courseSelect = editForm.querySelector('select[name="course"]');
+        const moduleSelect = editForm.querySelector('select[name="module"]');
+        const titleInput = editForm.querySelector('input[name="title"]');
+        const durationInput = editForm.querySelector('input[name="duration"]');
+        const typeSelect = editForm.querySelector('select[name="type"]');
+        const sourceInput = editForm.querySelector('input[name="source"]');
+        const summaryInput = editForm.querySelector('textarea[name="summary"]');
+
+        const selectedCourse = state.courses.find(course => course.id === courseSelect.value);
+        const selectedModule = selectedCourse ? selectedCourse.modules.find(module => module.id === moduleSelect.value) : null;
+        if (selectedModule) {
+            titleInput.value = selectedModule.title;
+            durationInput.value = selectedModule.duration;
+            typeSelect.value = selectedModule.type;
+            summaryInput.value = selectedModule.summary;
+            sourceInput.value = selectedModule.type === 'youtube'
+                ? `https://www.youtube.com/watch?v=${selectedModule.youtubeId}`
+                : selectedModule.source || '';
+        }
+
+        courseSelect.addEventListener('change', () => {
+            state.adminSelections.moduleCourse = courseSelect.value;
+            state.adminSelections.moduleEdit = '';
+            renderAdminPanel();
+        });
+
+        moduleSelect.addEventListener('change', () => {
+            state.adminSelections.moduleEdit = moduleSelect.value;
+            renderAdminPanel();
+        });
+
+        editForm.addEventListener('submit', event => {
+            event.preventDefault();
+            const course = state.courses.find(item => item.id === courseSelect.value);
+            if (!course) return;
+            const module = course.modules.find(item => item.id === moduleSelect.value);
+            if (!module) return;
+            module.title = titleInput.value;
+            module.duration = durationInput.value;
+            module.type = typeSelect.value;
+            module.summary = summaryInput.value;
+            if (module.type === 'youtube') {
+                const match = (sourceInput.value || '').match(/(?:v=|\.be\/|embed\/)([A-Za-z0-9_-]{11})/);
+                module.youtubeId = match ? match[1] : (sourceInput.value || '').slice(-11);
+                delete module.source;
+            } else {
+                module.source = sourceInput.value;
+                delete module.youtubeId;
+            }
+            renderAdminPanel();
+            renderOnlineTrainings();
+            showToast('Modül güncellendi.');
+        });
+    }
+
+    return card;
+}
+
+function createQuizManager() {
+    const card = document.createElement('div');
+    card.className = 'admin-card';
+    const { quizCourse, quizQuestion } = state.adminSelections;
+    const quizCourses = state.courses.filter(course => course.quiz && course.quiz.questions.length);
+    const selectedCourse = quizCourses.find(course => course.id === quizCourse) || quizCourses[0] || null;
+    const questions = selectedCourse ? selectedCourse.quiz.questions : [];
+    const selectedQuestionIndex = questions[Number(quizQuestion)] ? Number(quizQuestion) : 0;
+    const hasQuestions = quizCourses.length > 0;
+    card.innerHTML = `
+        <h3>Quiz Yönetimi</h3>
+        <form id="quizForm">
+            <select name="course" required>
+                <option value="">Kurs seçin</option>
+                ${state.courses.map(course => `<option value="${course.id}">${course.title}</option>`).join('')}
+            </select>
+            <input type="text" name="question" placeholder="Soru metni" required>
+            <input type="text" name="option1" placeholder="1. Şık" required>
+            <input type="text" name="option2" placeholder="2. Şık" required>
+            <input type="text" name="option3" placeholder="3. Şık" required>
+            <select name="answer" required>
+                <option value="0">1. Şık Doğru</option>
+                <option value="1">2. Şık Doğru</option>
+                <option value="2">3. Şık Doğru</option>
+            </select>
+            <button type="submit">Soru Ekle</button>
+        </form>
+        <div class="admin-divider"></div>
+        <h4>Quiz Düzenle</h4>
+        ${hasQuestions ? `
+            <form id="quizEditForm">
+                <select name="course" required>
+                    ${quizCourses.map(course => `<option value="${course.id}" ${selectedCourse && selectedCourse.id === course.id ? 'selected' : ''}>${course.title}</option>`).join('')}
+                </select>
+                <select name="question" required>
+                    ${questions.map((question, index) => `<option value="${index}" ${index === selectedQuestionIndex ? 'selected' : ''}>${index + 1}. Soru</option>`).join('')}
+                </select>
+                <input type="text" name="questionText" placeholder="Soru metni" required>
+                <input type="text" name="option1" placeholder="1. Şık" required>
+                <input type="text" name="option2" placeholder="2. Şık" required>
+                <input type="text" name="option3" placeholder="3. Şık" required>
+                <select name="answer" required>
+                    <option value="0">1. Şık Doğru</option>
+                    <option value="1">2. Şık Doğru</option>
+                    <option value="2">3. Şık Doğru</option>
+                </select>
+                <button type="submit">Soruyu Güncelle</button>
+            </form>
+        ` : '<p class="section-description">Düzenlenecek quiz sorusu bulunmuyor.</p>'}
+    `;
+
+    const form = card.querySelector('#quizForm');
+    form.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        const courseId = formData.get('course');
+        const course = state.courses.find(item => item.id === courseId);
+        if (!course) return;
+        course.quiz.questions.push({
+            text: formData.get('question'),
+            options: [formData.get('option1'), formData.get('option2'), formData.get('option3')],
+            answer: Number(formData.get('answer'))
+        });
+        form.reset();
+        renderAdminPanel();
+        showToast('Quiz sorusu eklendi.');
+    });
+
+    const editForm = card.querySelector('#quizEditForm');
+    if (editForm) {
+        const courseSelect = editForm.querySelector('select[name="course"]');
+        const questionSelect = editForm.querySelector('select[name="question"]');
+        const questionInput = editForm.querySelector('input[name="questionText"]');
+        const option1Input = editForm.querySelector('input[name="option1"]');
+        const option2Input = editForm.querySelector('input[name="option2"]');
+        const option3Input = editForm.querySelector('input[name="option3"]');
+        const answerSelect = editForm.querySelector('select[name="answer"]');
+
+        const selectedCourse = state.courses.find(item => item.id === courseSelect.value);
+        const selectedQuestion = selectedCourse ? selectedCourse.quiz.questions[Number(questionSelect.value)] : null;
+        if (selectedQuestion) {
+            questionInput.value = selectedQuestion.text;
+            option1Input.value = selectedQuestion.options[0] || '';
+            option2Input.value = selectedQuestion.options[1] || '';
+            option3Input.value = selectedQuestion.options[2] || '';
+            answerSelect.value = String(selectedQuestion.answer ?? 0);
+        }
+
+        courseSelect.addEventListener('change', () => {
+            state.adminSelections.quizCourse = courseSelect.value;
+            state.adminSelections.quizQuestion = '0';
+            renderAdminPanel();
+        });
+
+        questionSelect.addEventListener('change', () => {
+            state.adminSelections.quizQuestion = questionSelect.value;
+            renderAdminPanel();
+        });
+
+        editForm.addEventListener('submit', event => {
+            event.preventDefault();
+            const course = state.courses.find(item => item.id === courseSelect.value);
+            if (!course) return;
+            const index = Number(questionSelect.value);
+            const question = course.quiz.questions[index];
+            if (!question) return;
+            question.text = questionInput.value;
+            question.options = [option1Input.value, option2Input.value, option3Input.value];
+            question.answer = Number(answerSelect.value);
+            renderAdminPanel();
+            renderQuizzes();
+            showToast('Quiz sorusu güncellendi.');
+        });
+    }
+
+    return card;
+}
+
+function createPersonalManager() {
+    const card = document.createElement('div');
+    card.className = 'admin-card';
+    const { personal } = state.adminSelections;
+    card.innerHTML = `
+        <h3>Kişisel Gelişim İçerikleri</h3>
+        <form id="personalForm">
+            <input type="text" name="title" placeholder="Başlık" required>
+            <input type="text" name="icon" placeholder="Emoji (örn. 🔥)" maxlength="2" required>
+            <textarea name="body" placeholder="İçerik" required></textarea>
+            <button type="submit">İçerik Ekle</button>
+        </form>
+        <div class="inline-list">
+            ${state.personalDevelopment.map(item => `<button data-id="${item.id}"><span>${item.title}</span><i>Sil</i></button>`).join('')}
+        </div>
+        ${state.personalDevelopment.length ? `
+            <div class="admin-divider"></div>
+            <h4>İçerik Düzenle</h4>
+            <form id="personalEditForm">
+                <select name="content" required>
+                    ${state.personalDevelopment.map(item => `<option value="${item.id}" ${item.id === personal ? 'selected' : ''}>${item.title}</option>`).join('')}
+                </select>
+                <input type="text" name="title" placeholder="Başlık" required>
+                <input type="text" name="icon" placeholder="Emoji (örn. 🔥)" maxlength="2" required>
+                <textarea name="body" placeholder="İçerik" required></textarea>
+                <button type="submit">İçeriği Güncelle</button>
+            </form>
+        ` : ''}
+    `;
+
+    const form = card.querySelector('#personalForm');
+    form.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        const title = formData.get('title');
+        const id = title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+        state.personalDevelopment.push({
+            id,
+            title,
+            icon: formData.get('icon') || '📘',
+            body: formData.get('body')
+        });
+        form.reset();
+        renderAdminPanel();
+        renderPersonalGrowth();
+        showToast('Yeni kişisel gelişim içeriği eklendi.');
+    });
+
+    card.querySelectorAll('.inline-list button').forEach(button => {
+        button.addEventListener('click', () => {
+            const id = button.dataset.id;
+            state.personalDevelopment = state.personalDevelopment.filter(item => item.id !== id);
+            renderAdminPanel();
+            renderPersonalGrowth();
+            showToast('İçerik silindi.');
+        });
+    });
+
+    const editForm = card.querySelector('#personalEditForm');
+    if (editForm) {
+        const select = editForm.querySelector('select[name="content"]');
+        const titleInput = editForm.querySelector('input[name="title"]');
+        const iconInput = editForm.querySelector('input[name="icon"]');
+        const bodyInput = editForm.querySelector('textarea[name="body"]');
+        const selectedItem = state.personalDevelopment.find(item => item.id === select.value);
+        if (selectedItem) {
+            titleInput.value = selectedItem.title;
+            iconInput.value = selectedItem.icon;
+            bodyInput.value = selectedItem.body;
+        }
+
+        select.addEventListener('change', () => {
+            state.adminSelections.personal = select.value;
+            renderAdminPanel();
+        });
+
+        editForm.addEventListener('submit', event => {
+            event.preventDefault();
+            const target = state.personalDevelopment.find(item => item.id === select.value);
+            if (!target) return;
+            target.title = titleInput.value;
+            target.icon = iconInput.value || '📘';
+            target.body = bodyInput.value;
+            renderAdminPanel();
+            renderPersonalGrowth();
+            showToast('İçerik güncellendi.');
+        });
+    }
+
+    return card;
+}
+
+function createAnnouncementManager() {
+    const card = document.createElement('div');
+    card.className = 'admin-card';
+    const { announcement } = state.adminSelections;
+    card.innerHTML = `
+        <h3>Duyuru Yönetimi</h3>
+        <form id="announcementForm">
+            <input type="text" name="title" placeholder="Duyuru başlığı" required>
+            <input type="text" name="icon" placeholder="Emoji (örn. 📣)" maxlength="2" required>
+            <textarea name="body" placeholder="Duyuru metni" required></textarea>
+            <button type="submit">Duyuru Ekle</button>
+        </form>
+        <div class="inline-list">
+            ${state.announcements.map((item, index) => `<button data-index="${index}"><span>${item.title}</span><i>Sil</i></button>`).join('')}
+        </div>
+        ${state.announcements.length ? `
+            <div class="admin-divider"></div>
+            <h4>Duyuru Düzenle</h4>
+            <form id="announcementEditForm">
+                <select name="announcement" required>
+                    ${state.announcements.map((item, index) => `<option value="${index}" ${String(index) === announcement ? 'selected' : ''}>${item.title}</option>`).join('')}
+                </select>
+                <input type="text" name="title" placeholder="Duyuru başlığı" required>
+                <input type="text" name="icon" placeholder="Emoji (örn. 📣)" maxlength="2" required>
+                <textarea name="body" placeholder="Duyuru metni" required></textarea>
+                <button type="submit">Duyuruyu Güncelle</button>
+            </form>
+        ` : ''}
+    `;
+
+    const form = card.querySelector('#announcementForm');
+    form.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        state.announcements.push({
+            title: formData.get('title'),
+            icon: formData.get('icon') || '📢',
+            body: formData.get('body')
+        });
+        form.reset();
+        renderAdminPanel();
+        renderAnnouncements();
+        showToast('Duyuru eklendi.');
+    });
+
+    card.querySelectorAll('.inline-list button').forEach(button => {
+        button.addEventListener('click', () => {
+            const index = Number(button.dataset.index);
+            state.announcements.splice(index, 1);
+            renderAdminPanel();
+            renderAnnouncements();
+            showToast('Duyuru silindi.');
+        });
+    });
+
+    const editForm = card.querySelector('#announcementEditForm');
+    if (editForm) {
+        const select = editForm.querySelector('select[name="announcement"]');
+        const titleInput = editForm.querySelector('input[name="title"]');
+        const iconInput = editForm.querySelector('input[name="icon"]');
+        const bodyInput = editForm.querySelector('textarea[name="body"]');
+        const index = Number(select.value);
+        const selected = Number.isInteger(index) ? state.announcements[index] : null;
+        if (selected) {
+            titleInput.value = selected.title;
+            iconInput.value = selected.icon;
+            bodyInput.value = selected.body;
+        }
+
+        select.addEventListener('change', () => {
+            state.adminSelections.announcement = select.value;
+            renderAdminPanel();
+        });
+
+        editForm.addEventListener('submit', event => {
+            event.preventDefault();
+            const idx = Number(select.value);
+            if (!Number.isInteger(idx) || !state.announcements[idx]) return;
+            const announcementItem = state.announcements[idx];
+            announcementItem.title = titleInput.value;
+            announcementItem.icon = iconInput.value || '📣';
+            announcementItem.body = bodyInput.value;
+            renderAdminPanel();
+            renderAnnouncements();
+            showToast('Duyuru güncellendi.');
+        });
+    }
+
+    return card;
+}
+
+function createFaqManager() {
+    const card = document.createElement('div');
+    card.className = 'admin-card';
+    const { faq } = state.adminSelections;
+    card.innerHTML = `
+        <h3>SSS Yönetimi</h3>
+        <form id="faqForm">
+            <input type="text" name="question" placeholder="Soru" required>
+            <textarea name="answer" placeholder="Cevap" required></textarea>
+            <button type="submit">Soru Ekle</button>
+        </form>
+        <div class="inline-list">
+            ${state.faq.map((item, index) => `<button data-index="${index}"><span>${item.question}</span><i>Sil</i></button>`).join('')}
+        </div>
+        ${state.faq.length ? `
+            <div class="admin-divider"></div>
+            <h4>SSS Düzenle</h4>
+            <form id="faqEditForm">
+                <select name="faq" required>
+                    ${state.faq.map((item, index) => `<option value="${index}" ${String(index) === faq ? 'selected' : ''}>${item.question}</option>`).join('')}
+                </select>
+                <input type="text" name="question" placeholder="Soru" required>
+                <textarea name="answer" placeholder="Cevap" required></textarea>
+                <button type="submit">SSS Güncelle</button>
+            </form>
+        ` : ''}
+    `;
+
+    const form = card.querySelector('#faqForm');
+    form.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        state.faq.push({
+            question: formData.get('question'),
+            answer: formData.get('answer')
+        });
+        form.reset();
+        renderAdminPanel();
+        renderFaq();
+        showToast('Yeni SSS maddesi eklendi.');
+    });
+
+    card.querySelectorAll('.inline-list button').forEach(button => {
+        button.addEventListener('click', () => {
+            const index = Number(button.dataset.index);
+            state.faq.splice(index, 1);
+            renderAdminPanel();
+            renderFaq();
+            showToast('SSS maddesi silindi.');
+        });
+    });
+
+    const editForm = card.querySelector('#faqEditForm');
+    if (editForm) {
+        const select = editForm.querySelector('select[name="faq"]');
+        const questionInput = editForm.querySelector('input[name="question"]');
+        const answerInput = editForm.querySelector('textarea[name="answer"]');
+        const index = Number(select.value);
+        const selected = Number.isInteger(index) ? state.faq[index] : null;
+        if (selected) {
+            questionInput.value = selected.question;
+            answerInput.value = selected.answer;
+        }
+
+        select.addEventListener('change', () => {
+            state.adminSelections.faq = select.value;
+            renderAdminPanel();
+        });
+
+        editForm.addEventListener('submit', event => {
+            event.preventDefault();
+            const idx = Number(select.value);
+            if (!Number.isInteger(idx) || !state.faq[idx]) return;
+            const item = state.faq[idx];
+            item.question = questionInput.value;
+            item.answer = answerInput.value;
+            renderAdminPanel();
+            renderFaq();
+            showToast('SSS maddesi güncellendi.');
+        });
+    }
+
+    return card;
+}
+
+const supportButton = document.getElementById('openSupport');
+if (supportButton) {
+    supportButton.addEventListener('click', () => {
+        showToast('Destek talebiniz alındı. İK ekibi en kısa sürede sizinle iletişime geçecek.');
+    });
+}
+
+initProgress();
+renderView('online-trainings');

--- a/index.html
+++ b/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Çalışan Gelişim Merkezi</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="app-shell">
+        <aside class="sidebar">
+            <div class="brand">
+                <div class="brand-logo">Y</div>
+                <div class="brand-text">
+                    <h1>Yenilikle</h1>
+                    <span>Gelişim Merkezi</span>
+                </div>
+            </div>
+            <nav class="nav-menu">
+                <button class="nav-item active" data-target="online-trainings">
+                    <span>Online Eğitimler</span>
+                </button>
+                <button class="nav-item" data-target="quizzes">
+                    <span>Quizler ve Sertifikalar</span>
+                </button>
+                <button class="nav-item" data-target="personal-growth">
+                    <span>Kişisel Gelişim</span>
+                </button>
+                <button class="nav-item" data-target="faq">
+                    <span>Sıkça Sorulan Sorular</span>
+                </button>
+                <button class="nav-item" data-target="announcements">
+                    <span>Duyurular ve Etkinlikler</span>
+                </button>
+                <button class="nav-item" data-target="admin">
+                    <span>Yönetim Paneli</span>
+                </button>
+            </nav>
+            <div class="support-card">
+                <h3>Yardım mı lazım?</h3>
+                <p>İK ekibimiz tüm süreçlerde yanınızda.</p>
+                <button id="openSupport">Destek Talebi Oluştur</button>
+            </div>
+        </aside>
+        <div class="content-area">
+            <header class="top-bar">
+                <div class="status-badges">
+                    <span class="badge badge-online">🟢 Online</span>
+                    <span class="badge badge-meeting">🧑‍💻 Online Toplantı</span>
+                    <span class="badge badge-training">🎓 Proje Stajı</span>
+                </div>
+                <div class="user-info">
+                    <div class="user-meta">
+                        <h2>Merhaba, Kenan!</h2>
+                        <p>Bugün öğrenmeye devam edelim.</p>
+                    </div>
+                    <div class="user-avatar">MK</div>
+                </div>
+            </header>
+            <main class="main-content">
+                <section id="online-trainings" class="view active-view"></section>
+                <section id="quizzes" class="view"></section>
+                <section id="personal-growth" class="view"></section>
+                <section id="faq" class="view"></section>
+                <section id="announcements" class="view"></section>
+                <section id="admin" class="view"></section>
+            </main>
+        </div>
+    </div>
+    <div class="modal" id="quizModal" aria-hidden="true">
+        <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="quizModalTitle">
+            <button class="modal-close" id="closeQuizModal" aria-label="Kapat">×</button>
+            <div class="modal-content" id="quizModalContent"></div>
+        </div>
+    </div>
+    <div class="toast-container" aria-live="polite" aria-atomic="true"></div>
+    <script src="https://www.youtube.com/iframe_api"></script>
+    <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,762 @@
+:root {
+    --bg: #f3f5fb;
+    --sidebar: #1f2937;
+    --sidebar-light: #374151;
+    --primary: #4f46e5;
+    --primary-dark: #4338ca;
+    --accent: #22c55e;
+    --danger: #ef4444;
+    --warning: #f59e0b;
+    --text-dark: #111827;
+    --text: #4b5563;
+    --card: #ffffff;
+    --border: #e5e7eb;
+    font-family: 'Inter', sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text-dark);
+    font-family: 'Inter', sans-serif;
+    min-height: 100vh;
+}
+
+.app-shell {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    min-height: 100vh;
+}
+
+.sidebar {
+    background: var(--sidebar);
+    color: #f9fafb;
+    display: flex;
+    flex-direction: column;
+    padding: 32px 24px;
+    gap: 32px;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.brand-logo {
+    background: var(--primary);
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    font-size: 22px;
+}
+
+.brand-text h1 {
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.brand-text span {
+    font-size: 13px;
+    color: #d1d5db;
+}
+
+.nav-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.nav-item {
+    background: transparent;
+    border: none;
+    color: #d1d5db;
+    text-align: left;
+    padding: 12px 16px;
+    border-radius: 12px;
+    font-size: 15px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav-item.active,
+.nav-item:hover {
+    background: rgba(79, 70, 229, 0.18);
+    color: #ffffff;
+}
+
+.nav-item.locked {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.support-card {
+    margin-top: auto;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 16px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.support-card h3 {
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.support-card button {
+    background: #f9fafb;
+    border: none;
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--sidebar);
+    transition: transform 0.2s ease;
+}
+
+.support-card button:hover {
+    transform: translateY(-2px);
+}
+
+.content-area {
+    display: flex;
+    flex-direction: column;
+}
+
+.top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px 32px;
+}
+
+.status-badges {
+    display: flex;
+    gap: 12px;
+}
+
+.badge {
+    padding: 8px 14px;
+    border-radius: 30px;
+    font-size: 13px;
+    font-weight: 600;
+    background: #e0e7ff;
+    color: var(--primary-dark);
+}
+
+.badge-meeting {
+    background: #dcfce7;
+    color: var(--accent);
+}
+
+.badge-training {
+    background: #fef9c3;
+    color: var(--warning);
+}
+
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.user-meta h2 {
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.user-meta p {
+    font-size: 14px;
+    color: var(--text);
+}
+
+.user-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: var(--primary);
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    color: white;
+}
+
+.main-content {
+    flex: 1;
+    padding: 0 32px 40px;
+}
+
+.view {
+    display: none;
+}
+
+.view.active-view {
+    display: block;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.section-header h2 {
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.section-description {
+    color: var(--text);
+    font-size: 15px;
+}
+
+.course-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 20px;
+}
+
+.course-card {
+    background: var(--card);
+    border-radius: 20px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    position: relative;
+}
+
+.course-card.locked::after {
+    content: "🔒 Önceki eğitimi tamamlayın";
+    position: absolute;
+    inset: 0;
+    background: rgba(17, 24, 39, 0.72);
+    color: white;
+    border-radius: 20px;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    padding: 24px;
+    font-weight: 600;
+}
+
+.course-card h3 {
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.module-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.module-item {
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: #f9fafb;
+    cursor: pointer;
+    position: relative;
+    transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.module-item:hover {
+    border-color: var(--primary);
+    transform: translateY(-2px);
+}
+
+.module-item.locked {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.module-meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 13px;
+    color: var(--text);
+}
+
+.progress-bar {
+    height: 8px;
+    background: #e5e7eb;
+    border-radius: 20px;
+    overflow: hidden;
+}
+
+.progress-bar span {
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, var(--primary), var(--accent));
+    width: 0;
+}
+
+.player-panel {
+    margin-top: 32px;
+    background: var(--card);
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.player-panel h3 {
+    font-size: 22px;
+    margin-bottom: 12px;
+}
+
+#videoContainer {
+    background: #0f172a;
+    border-radius: 16px;
+    overflow: hidden;
+    position: relative;
+}
+
+#videoContainer video,
+#videoContainer iframe {
+    width: 100%;
+    height: 360px;
+}
+
+.training-progress-summary {
+    margin-top: 18px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.training-progress-summary .percentage {
+    font-weight: 600;
+    color: var(--primary);
+}
+
+.quiz-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 24px;
+}
+
+.quiz-card {
+    background: var(--card);
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.quiz-card h3 {
+    font-size: 20px;
+}
+
+.quiz-result {
+    display: flex;
+    gap: 12px;
+    font-size: 14px;
+}
+
+.quiz-result span {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.quiz-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.quiz-actions button {
+    background: var(--primary);
+    color: white;
+    border: none;
+    padding: 10px 16px;
+    border-radius: 12px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.quiz-actions button:disabled {
+    background: #c7d2fe;
+    color: #4f46e5;
+    cursor: not-allowed;
+}
+
+.badge-pass {
+    color: var(--accent);
+    font-weight: 600;
+}
+
+.badge-fail {
+    color: var(--danger);
+    font-weight: 600;
+}
+
+.certificate-banner {
+    margin-top: 32px;
+    background: linear-gradient(135deg, rgba(79, 70, 229, 0.85), rgba(37, 99, 235, 0.95));
+    color: white;
+    padding: 28px;
+    border-radius: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 10px 30px rgba(37, 99, 235, 0.35);
+}
+
+.certificate-banner strong {
+    font-size: 20px;
+}
+
+.certificate-banner button {
+    align-self: flex-start;
+    background: white;
+    color: var(--primary);
+    border: none;
+    padding: 10px 18px;
+    border-radius: 12px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.personal-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.personal-card {
+    background: var(--card);
+    border-radius: 20px;
+    padding: 24px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    cursor: pointer;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.personal-card:hover {
+    transform: translateY(-4px);
+}
+
+.personal-card img {
+    width: 64px;
+    margin: 0 auto;
+}
+
+.personal-reader {
+    margin-top: 32px;
+    background: var(--card);
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.personal-reader h3 {
+    margin-bottom: 12px;
+}
+
+.accordion {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.accordion-item {
+    background: var(--card);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+}
+
+.accordion-button {
+    width: 100%;
+    background: transparent;
+    border: none;
+    text-align: left;
+    padding: 16px 20px;
+    font-weight: 600;
+    font-size: 15px;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.accordion-content {
+    padding: 0 20px 16px;
+    color: var(--text);
+    font-size: 14px;
+}
+
+.announcement-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.announcement-card {
+    background: var(--card);
+    border-radius: 20px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.announcement-icon {
+    font-size: 24px;
+}
+
+.admin-panel {
+    display: grid;
+    gap: 24px;
+}
+
+.admin-card {
+    background: var(--card);
+    border-radius: 20px;
+    padding: 24px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.admin-card h4 {
+    margin: 20px 0 8px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.admin-divider {
+    height: 1px;
+    background: var(--border);
+    margin: 20px 0;
+    border-radius: 999px;
+}
+
+.admin-card form {
+    display: grid;
+    gap: 12px;
+}
+
+input[type="text"],
+input[type="url"],
+textarea,
+select {
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    font-size: 14px;
+    font-family: inherit;
+    resize: vertical;
+}
+
+textarea {
+    min-height: 80px;
+}
+
+.admin-card button,
+.modal-content button.primary {
+    background: var(--primary);
+    color: white;
+    border: none;
+    padding: 10px 14px;
+    border-radius: 10px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.inline-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.inline-list button {
+    background: none;
+    border: 1px dashed var(--border);
+    padding: 8px 12px;
+    border-radius: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.inline-list button span {
+    flex: 1;
+    text-align: left;
+}
+
+.inline-list button i {
+    color: var(--danger);
+    font-style: normal;
+    font-weight: 600;
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.6);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    padding: 32px;
+    z-index: 1000;
+}
+
+.modal.show {
+    display: flex;
+}
+
+.modal-dialog {
+    background: var(--card);
+    border-radius: 24px;
+    width: min(640px, 100%);
+    max-height: calc(100vh - 80px);
+    overflow: hidden;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.modal-close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: rgba(15, 23, 42, 0.08);
+    border: none;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    font-size: 22px;
+    cursor: pointer;
+}
+
+.modal-content {
+    padding: 28px 32px;
+    overflow-y: auto;
+}
+
+.quiz-question {
+    display: grid;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+
+.quiz-question h4 {
+    font-size: 16px;
+}
+
+.quiz-options {
+    display: grid;
+    gap: 8px;
+}
+
+.quiz-options label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+}
+
+.quiz-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.toast-container {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    display: grid;
+    gap: 12px;
+    z-index: 1500;
+}
+
+.toast {
+    background: #111827;
+    color: white;
+    padding: 12px 16px;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
+    font-size: 14px;
+    opacity: 0;
+    transform: translateY(10px);
+    animation: toast-in 0.4s forwards;
+}
+
+@keyframes toast-in {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.empty-state {
+    text-align: center;
+    padding: 40px;
+    color: var(--text);
+}
+
+.badge-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    background: rgba(34, 197, 94, 0.12);
+    color: var(--accent);
+}
+
+@media (max-width: 960px) {
+    .app-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        position: fixed;
+        inset: 0 auto 0 0;
+        width: 260px;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        z-index: 1200;
+    }
+
+    .sidebar.open {
+        transform: translateX(0);
+    }
+
+    .top-bar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+}


### PR DESCRIPTION
## Summary
- maintain admin panel selection state and normalize it before rendering
- add edit forms that list existing courses, modules, quizzes, personal posts, announcements, and FAQ entries with their current values
- style the admin edit sections with dividers and headings for clarity

## Testing
- Manual verification pending

------
https://chatgpt.com/codex/tasks/task_e_68e66358e298833399adc014a3b843ec